### PR TITLE
Update Set-PnPWikiPageContent.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPWikiPageContent.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPWikiPageContent.md
@@ -91,7 +91,8 @@ Required: False
 Position: Named
 Accept pipeline input: False
 ```
-
+## NOTES
+Set-PnPWikiPageContent Cmdlet works with Modern sites. It does not work with the wiki pages created with the classic Enterprise Wiki template.
 ## RELATED LINKS
 
 [SharePoint Developer Patterns and Practices](https://aka.ms/sppnp)


### PR DESCRIPTION
Added notes - Set-PnPWikiPageContent Cmdlet works with Modern sites. It does not work with the wiki pages created with the classic Enterprise Wiki template.